### PR TITLE
update wp version 6.2-ja

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-  "core": null,
+  "core": "https://ja.wordpress.org/wordpress-6.2-ja.zip",
   "plugins": [
     "https://downloads.wordpress.org/plugin/query-monitor.3.7.1.zip",
     "https://downloads.wordpress.org/plugin/wp-multibyte-patch.2.9.zip",


### PR DESCRIPTION
`wp-env.json`の`core`を`https://ja.wordpress.org/wordpress-6.2-ja.zip`に変更